### PR TITLE
drivers: video: console: support LLCON logs

### DIFF
--- a/drivers/video/console/Kconfig
+++ b/drivers/video/console/Kconfig
@@ -129,6 +129,11 @@ config STI_CONSOLE
           machines.  Say Y here to build support for it into your kernel.
           The alternative is to use your primary serial port as a console.
 
+config LLCON
+	bool "Low level console"
+	default n
+	select FONTS
+
 config FONTS
 	bool "Select compiled-in fonts"
 	depends on FRAMEBUFFER_CONSOLE || STI_CONSOLE
@@ -225,4 +230,3 @@ config FONT_10x18
 	  If other fonts are too big or too small for you, say Y, otherwise say N.
 
 endmenu
-

--- a/drivers/video/console/Makefile
+++ b/drivers/video/console/Makefile
@@ -18,6 +18,8 @@ font-objs-$(CONFIG_FONT_MINI_4x6)  += font_mini_4x6.o
 
 font-objs += $(font-objs-y)
 
+obj-$(CONFIG_LLCON) += llcon.o
+
 # Each configuration option enables a list of files.
 
 obj-$(CONFIG_DUMMY_CONSOLE)       += dummycon.o

--- a/drivers/video/console/llcon.c
+++ b/drivers/video/console/llcon.c
@@ -1,0 +1,201 @@
+/**
+ * @file drivers/video/console/llcon.c
+ *
+ * @brief
+ * This file contains the implementation of Low Level Console
+ * for output kernel messages to display.
+ * This module support only 24-bit color format.
+ *
+ * @author	remittor <remittor@gmail.com>
+ * @date	2016-05-11
+ */
+
+#include <linux/slab.h>
+#include <linux/kernel.h>
+#include <linux/mm.h>
+#include <linux/delay.h>
+#include <linux/console.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/moduleparam.h>
+#include <linux/memblock.h>
+#include <linux/io.h>
+#include <linux/vmalloc.h>
+#include <linux/kmsg_dump.h>
+
+#include <video/llcon.h>
+
+volatile int llcon_enabled = 0;
+volatile int llcon_dumplog = 0;
+
+void llcon_dmp_putc(char c);
+int llcon_dmp_init(void);
+
+struct mutex llcon_lock;
+
+static struct llcon_desc llcon;
+
+/*
+ * llcondmp=<start_addr>,<size>
+ */
+
+static int __init llcondmp_setup(char *str)
+{
+	llcon.mode = LLCON_MODE_DISABLED;
+	int ints[4];
+	void * addr;
+	size_t size;
+
+	str = get_options(str, 3, ints);
+	if (!ints[0])
+		return 1;
+
+	switch (ints[0]) {
+	case 2:
+		size = (size_t)ints[2];
+	case 1:
+		addr = (void *)ints[1];
+	}
+	if (size && addr)
+		llcon_dmp_reserve_ram(addr, size);
+	return 1;
+}
+__setup("llcondmp=", llcondmp_setup);
+
+void inline __llcon_emit(char c)
+{
+	if (llcon_dumplog) {
+		llcon_dmp_putc(c);
+	}
+}
+
+void llcon_emit(char c)
+{
+	__llcon_emit(c);
+}
+
+void llcon_emit_line(char * line, int size)
+{
+	int i;
+	if (line && size > 0) {
+		for (i = 0; i < size; i++) {
+			__llcon_emit(line[i]);
+		}
+	}
+}
+
+struct llcon_desc * llcon_get(void)
+{
+	return &llcon;
+}
+
+void llcon_uninit(void)
+{
+	if (llcon_enabled) {
+		pr_info("LLCON: exit \n");
+
+		llcon_enabled = 0;
+	}
+}
+
+
+int llcon_dmp_reserve_ram(void * addr, size_t size)
+{
+	int rc;
+
+	if (llcon.dmp.phys_addr && llcon.dmp.vmem_size)
+		return 0;
+	rc = memblock_reserve((phys_addr_t)addr, (phys_addr_t)size);
+	if (rc) {
+		llcon.dmp.phys_addr = 0;
+		llcon.dmp.vmem_size = 0;
+		llcon.dmp.virt_addr = 0;
+		pr_err("Failed to reserve memory at 0x%lx (size = 0x%lx) \n",
+			(long)addr, (long)size);
+		return -ENOMEM;
+	}
+	llcon.dmp.phys_addr = addr;
+	llcon.dmp.vmem_size = size;
+	llcon.dmp.virt_addr = 0;
+	return 0;
+}
+
+int llcon_dmp_syslog(void)
+{
+	struct kmsg_dumper dumper = { .active = 1 };
+	static char buf[1024];
+	size_t i, len;
+	int total = 0;
+
+	kmsg_dump_rewind_nolock(&dumper);
+	while (kmsg_dump_get_line_nolock(&dumper, true, buf, sizeof(buf), &len)) {
+		for (i=0; i < len; i++) {
+			llcon_dmp_putc(buf[i]);
+		}
+		total += (int)len;
+	}
+	return total;
+}
+
+int llcon_dmp_init(void)
+{
+	size_t pcnt;
+	size_t x;
+	pgprot_t prot;
+	struct page **pages;
+	phys_addr_t addr;
+	void * virt_addr = NULL;
+	struct llcon_dmp_header * hdr;
+	uint32_t cur_zone = 0;
+
+	if (llcon_dumplog || llcon.dmp.virt_addr)
+		return 0;
+		
+	if (!llcon.dmp.phys_addr || !llcon.dmp.vmem_size)
+		return -ENOMEM;
+
+	pcnt = llcon.dmp.vmem_size / PAGE_SIZE;
+	prot = pgprot_noncached(PAGE_KERNEL);
+	pages = kmalloc(sizeof(struct page *) * pcnt, GFP_KERNEL);
+	if (!pages) return -100;
+	for (x = 0; x < pcnt; x++) {
+		addr = (phys_addr_t)llcon.dmp.phys_addr + x * PAGE_SIZE;
+		pages[x] = pfn_to_page(addr >> PAGE_SHIFT);
+	} 
+	virt_addr = vmap(pages, pcnt, VM_MAP, prot);
+	kfree(pages);
+	if (!virt_addr) return -200;
+
+	hdr = (struct llcon_dmp_header *)virt_addr;
+	if (hdr->magic != LLCON_DMP_MAGIC) {
+		hdr->magic = LLCON_DMP_MAGIC;
+		hdr->cur_zone = 0;
+		hdr->zone_cnt[0] = 1;
+		hdr->zone_cnt[1] = 0;
+	} else {
+		cur_zone = hdr->cur_zone & 1;
+		cur_zone = (cur_zone ? 0 : 1);
+		hdr->cur_zone = cur_zone;
+		hdr->zone_cnt[cur_zone]++;
+	}
+	llcon.dmp.bufsize = llcon.dmp.vmem_size / 2 - sizeof(struct llcon_dmp_header);
+	llcon.dmp.buf = (char *)virt_addr + sizeof(struct llcon_dmp_header);
+	if (cur_zone) 
+		llcon.dmp.buf += llcon.dmp.bufsize;
+
+	memset(llcon.dmp.buf, 0, llcon.dmp.bufsize);
+	llcon.dmp.pos = 0;
+	llcon.dmp.virt_addr = virt_addr;
+	llcon_dumplog = 1;
+	llcon_dmp_syslog();
+	return 0;
+}
+
+void llcon_dmp_putc(char c)
+{
+	if (!llcon_dumplog)
+		return;
+	if (llcon.dmp.pos >= llcon.dmp.bufsize)
+		llcon.dmp.pos = 0;
+	llcon.dmp.buf[llcon.dmp.pos++] = c;
+}

--- a/include/video/llcon.h
+++ b/include/video/llcon.h
@@ -1,0 +1,121 @@
+/**
+ * @file include/video/llcon.h
+ *
+ * @brief
+ * This file contains the implementation of Low Level Console
+ * for output kernel messages to display.
+ *
+ * @author	remittor <remittor@gmail.com>
+ * @date	2016-05-11
+ */
+
+#include <linux/kthread.h>
+#include <linux/sched.h>
+#include <linux/font.h>
+
+#define LLCON_DMP_MAGIC      (0xFACEFACE)
+
+#define LLCON_MODE_DISABLED  0
+#define LLCON_MODE_SYNC      1
+#define LLCON_MODE_ASYNC     2
+#define LLCON_MODE_MAX       3
+
+#define LLCON_BLACK     0x000000
+#define LLCON_WHITE     0xFFFFFF
+#define LLCON_GREEN     0x008000
+
+struct llcon_pos {
+	size_t x;
+	size_t y;
+};
+
+struct llcon_display {
+	void * bl_fbaddr;
+	void * dt_fbaddr;
+	void * fbaddr;
+	size_t width;
+	size_t height;
+	size_t stride;
+	size_t bpp;
+	size_t pixel_size;
+};
+
+struct llcon_log {
+	char * buf;
+	size_t bufsize;
+	size_t pos;
+	struct llcon_pos cur;
+};
+
+struct llcon_dmp {
+	void * phys_addr;
+	void * virt_addr;
+	size_t vmem_size;
+	char * buf;
+	size_t bufsize;
+	size_t pos;
+};
+
+struct llcon_desc {
+	int mode;
+	int textwrap;
+	size_t delay;
+	struct llcon_display display;
+	struct font_desc font;
+	size_t glyph_stride;
+	uint32_t fg_color;
+	uint32_t bg_color;
+	struct llcon_pos cur;
+	struct llcon_pos res;
+	struct llcon_pos max;
+	struct task_struct * task;
+	struct llcon_log log;
+	struct llcon_dmp dmp;
+};
+
+extern volatile int llcon_enabled;
+extern volatile int llcon_dumplog;
+
+void llcon_emit(char c);
+void llcon_emit_line(char * line, int size);
+struct llcon_desc * llcon_get(void);
+void llcon_uninit(void);
+
+static inline void llcon_emit_log_char(char c)
+{
+	if (llcon_enabled || llcon_dumplog) {
+		llcon_emit(c);
+	}
+}
+
+static inline void llcon_emit_log_line(char * line, int size)
+{
+	if (llcon_enabled || llcon_dumplog) {
+		llcon_emit_line(line, size);
+	}
+}
+
+static inline void llcon_exit(void)
+{
+	if (llcon_enabled || llcon_dumplog) {
+		llcon_uninit();
+	}
+}
+
+
+struct llcon_dmp_header {
+	uint32_t magic;
+	uint32_t cur_zone;
+	uint32_t zone_cnt[2];
+};
+
+int llcon_dmp_reserve_ram(void * addr, size_t size);
+int llcon_dmp_init(void);
+
+
+#define llcon_dbg_set_fb_vmem(...)    do {} while(0)
+#define llcon_dbg_buf(...)     do {} while(0)
+#define llcon_dbg_u16(...)     do {} while(0)
+#define llcon_dbg_text(...)    do {} while(0)
+#define llcon_dbg(...)         do {} while(0)
+#define llcon_dbg_vline(...)   do {} while(0)

--- a/init/main.c
+++ b/init/main.c
@@ -69,6 +69,10 @@
 #include <linux/slab.h>
 #include <linux/perf_event.h>
 
+#ifdef CONFIG_LLCON
+#include <video/llcon.h>
+#endif
+
 #include <asm/io.h>
 #include <asm/bugs.h>
 #include <asm/setup.h>
@@ -772,6 +776,9 @@ static void __init do_initcalls(void)
  */
 static void __init do_basic_setup(void)
 {
+#ifdef CONFIG_LLCON
+	llcon_dmp_init();
+#endif
 	cpuset_init_smp();
 	usermodehelper_init();
 	shmem_init();

--- a/kernel/printk.c
+++ b/kernel/printk.c
@@ -43,6 +43,10 @@
 #include <linux/rculist.h>
 #include <linux/poll.h>
 
+#ifdef CONFIG_LLCON
+#include <video/llcon.h>
+#endif
+
 #include <asm/uaccess.h>
 
 #include <mach/msm_rtb.h>
@@ -287,6 +291,11 @@ static u32 log_next(u32 idx)
 #define LOG_ALIGN 8
 #endif
 
+#ifdef CONFIG_LLCON
+static size_t msg_print_text(const struct log *msg, enum log_flags prev,
+                             bool syslog, char *buf, size_t size);
+#endif
+
 /* insert record into the buffer, discard old ones, update heads */
 static void log_store(int facility, int level,
 			const char *dict, u16 dict_len,
@@ -336,6 +345,18 @@ static void log_store(int facility, int level,
 	msg->ts_nsec = local_clock();
 	memset(log_dict(msg) + dict_len, 0, pad_len);
 	msg->len = sizeof(struct log) + text_len + dict_len + pad_len;
+
+#ifdef CONFIG_LLCON
+	if (llcon_enabled || llcon_dumplog) {
+		static char llcon_buf[LOG_LINE_MAX + PREFIX_MAX + 32];
+		size_t mlen;
+		msg->flags = LOG_NEWLINE | LOG_PREFIX;
+		mlen = msg_print_text(msg, 0, true, llcon_buf, sizeof(llcon_buf));
+		if (mlen > 0)
+			llcon_emit_log_line(llcon_buf, mlen);
+		msg->flags = flags & 0x1f;
+	}
+#endif
 
 	/* insert message */
 	log_next_idx += msg->len;


### PR DESCRIPTION
It is a lighter version of LLCON driver from @remittor which just works as log dumper into a reserved memory region parsing the parameters from llcondmp=<start_addr>,<size> from cmdline.